### PR TITLE
citra_qt: Display game's long title in the window title bar and elsewhere

### DIFF
--- a/src/citra_qt/configuration/configure_web.cpp
+++ b/src/citra_qt/configuration/configure_web.cpp
@@ -15,7 +15,7 @@ ConfigureWeb::ConfigureWeb(QWidget* parent)
     ui->setupUi(this);
 
 #ifndef USE_DISCORD_PRESENCE
-    ui->discord_group->setVisible(false);
+    ui->discord_group->setEnabled(false);
 #endif
     SetConfiguration();
 }

--- a/src/citra_qt/discord_impl.cpp
+++ b/src/citra_qt/discord_impl.cpp
@@ -37,7 +37,7 @@ void DiscordImpl::Update() {
     std::string title;
     const bool is_powered_on = system.IsPoweredOn();
     if (is_powered_on) {
-        system.GetAppLoader().ReadTitle(title);
+        system.GetAppLoader().ReadTitleLong(title);
     }
 
     DiscordRichPresence presence{};

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -3164,10 +3164,11 @@ void GMainWindow::UpdateWindowTitle() {
         setWindowTitle(QStringLiteral("Citra %1").arg(full_name));
     } else {
         setWindowTitle(QStringLiteral("Citra %1 | %2").arg(full_name, game_title_long));
-        render_window->setWindowTitle(
-            QStringLiteral("Citra %1 | %2 | %3").arg(full_name, game_title_long, tr("Primary Window")));
+        render_window->setWindowTitle(QStringLiteral("Citra %1 | %2 | %3")
+                                          .arg(full_name, game_title_long, tr("Primary Window")));
         secondary_window->setWindowTitle(
-            QStringLiteral("Citra %1 | %2 | %3").arg(full_name, game_title_long, tr("Secondary Window")));
+            QStringLiteral("Citra %1 | %2 | %3")
+                .arg(full_name, game_title_long, tr("Secondary Window")));
     }
 }
 

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -1231,8 +1231,11 @@ bool GMainWindow::LoadROM(const QString& filename) {
     }
 
     std::string title;
+    std::string title_long;
     system.GetAppLoader().ReadTitle(title);
+    system.GetAppLoader().ReadTitleLong(title_long);
     game_title = QString::fromStdString(title);
+    game_title_long = QString::fromStdString(title_long);
     UpdateWindowTitle();
 
     game_path = filename;
@@ -3156,14 +3159,14 @@ void GMainWindow::OnMoviePlaybackCompleted() {
 void GMainWindow::UpdateWindowTitle() {
     const QString full_name = QString::fromUtf8(Common::g_build_fullname);
 
-    if (game_title.isEmpty()) {
+    if (game_title_long.isEmpty()) {
         setWindowTitle(QStringLiteral("Citra %1").arg(full_name));
     } else {
-        setWindowTitle(QStringLiteral("Citra %1 | %2").arg(full_name, game_title));
+        setWindowTitle(QStringLiteral("Citra %1 | %2").arg(full_name, game_title_long));
         render_window->setWindowTitle(
-            QStringLiteral("Citra %1 | %2 | %3").arg(full_name, game_title, tr("Primary Window")));
-        secondary_window->setWindowTitle(QStringLiteral("Citra %1 | %2 | %3")
-                                             .arg(full_name, game_title, tr("Secondary Window")));
+            QStringLiteral("Citra %1 | %2 | %3").arg(full_name, game_title_long, tr("Primary Window")));
+        secondary_window->setWindowTitle(
+            QStringLiteral("Citra %1 | %2 | %3").arg(full_name, game_title_long, tr("Secondary Window")));
     }
 }
 

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -1481,6 +1481,7 @@ void GMainWindow::ShutdownGame() {
 #endif
 
     game_title.clear();
+    game_title_long.clear();
     UpdateWindowTitle();
 
     game_path.clear();

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -323,6 +323,7 @@ private:
     std::unique_ptr<EmuThread> emu_thread;
     // The title of the game currently running
     QString game_title;
+    QString game_title_long;
     // The path to the game currently running
     QString game_path;
 

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -258,11 +258,20 @@ public:
     }
 
     /**
-     * Get the title of the application
+     * Get the short title of the application
      * @param title Reference to store the application title into
      * @return ResultStatus result of function
      */
     virtual ResultStatus ReadTitle([[maybe_unused]] std::string& title) {
+        return ResultStatus::ErrorNotImplemented;
+    }
+
+    /**
+     * Get the long title of the application
+     * @param title Referencec to store the application title into
+     * @param ResultStatus result of function
+     */
+    virtual ResultStatus ReadTitleLong([[maybe_unused]]std::string& title) {
         return ResultStatus::ErrorNotImplemented;
     }
 

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -271,7 +271,7 @@ public:
      * @param title Referencec to store the application title into
      * @param ResultStatus result of function
      */
-    virtual ResultStatus ReadTitleLong([[maybe_unused]]std::string& title) {
+    virtual ResultStatus ReadTitleLong([[maybe_unused]] std::string& title) {
         return ResultStatus::ErrorNotImplemented;
     }
 

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -380,4 +380,22 @@ ResultStatus AppLoader_NCCH::ReadTitle(std::string& title) {
     return ResultStatus::Success;
 }
 
+ResultStatus AppLoader_NCCH::ReadTitleLong(std::string& title) {
+    std::vector<u8> data;
+    Loader::SMDH smdh;
+    ReadIcon(data);
+
+    if (!Loader::IsValidSMDH(data)) {
+        return ResultStatus::ErrorInvalidFormat;
+    }
+
+    std::memcpy(&smdh, data.data(), sizeof(Loader::SMDH));
+
+    const auto& long_title = smdh.GetLongTitle(SMDH::TitleLanguage::English);
+    auto title_end = std::find(long_title.begin(), long_title.end(), u'\0');
+    title = Common::UTF16ToUTF8(std::u16string{long_title.begin(), title_end});
+
+    return ResultStatus::Success;
+}
+
 } // namespace Loader

--- a/src/core/loader/ncch.h
+++ b/src/core/loader/ncch.h
@@ -70,6 +70,7 @@ public:
     ResultStatus DumpUpdateRomFS(const std::string& target_path) override;
 
     ResultStatus ReadTitle(std::string& title) override;
+    ResultStatus ReadTitleLong(std::string& title) override;
 
 private:
     /**


### PR DESCRIPTION
Ported from Lime3DS.