### PR TITLE
citra_qt: Add Single Screen/Separate Windows layout configuration options

### DIFF
--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -190,6 +190,13 @@ void Config::ReadValues() {
     ReadSetting("Layout", Settings::values.custom_bottom_height);
     ReadSetting("Layout", Settings::values.new_custom_second_layer_opacity);
 
+    ReadSetting("Layout", Settings::values.screen_top_stretch);
+    ReadSetting("Layout", Settings::values.screen_top_leftright_padding);
+    ReadSetting("Layout", Settings::values.screen_top_topbottom_padding);
+    ReadSetting("Layout", Settings::values.screen_bottom_stretch);
+    ReadSetting("Layout", Settings::values.screen_bottom_leftright_padding);
+    ReadSetting("Layout", Settings::values.screen_bottom_topbottom_padding);
+
     // Utility
     ReadSetting("Utility", Settings::values.dump_textures);
     ReadSetting("Utility", Settings::values.custom_textures);

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -542,6 +542,13 @@ void Config::ReadLayoutValues() {
         ReadBasicSetting(Settings::values.custom_bottom_height);
 
         ReadBasicSetting(Settings::values.custom_second_layer_opacity);
+
+        ReadBasicSetting(Settings::values.screen_top_stretch);
+        ReadBasicSetting(Settings::values.screen_top_leftright_padding);
+        ReadBasicSetting(Settings::values.screen_top_topbottom_padding);
+        ReadBasicSetting(Settings::values.screen_bottom_stretch);
+        ReadBasicSetting(Settings::values.screen_bottom_leftright_padding);
+        ReadBasicSetting(Settings::values.screen_bottom_topbottom_padding);
     }
 
     qt_config->endGroup();
@@ -1101,6 +1108,13 @@ void Config::SaveLayoutValues() {
         WriteBasicSetting(Settings::values.custom_bottom_height);
 
         WriteBasicSetting(Settings::values.custom_second_layer_opacity);
+
+        WriteBasicSetting(Settings::values.screen_top_stretch);
+        WriteBasicSetting(Settings::values.screen_top_leftright_padding);
+        WriteBasicSetting(Settings::values.screen_top_topbottom_padding);
+        WriteBasicSetting(Settings::values.screen_bottom_stretch);
+        WriteBasicSetting(Settings::values.screen_bottom_leftright_padding);
+        WriteBasicSetting(Settings::values.screen_bottom_topbottom_padding);
     }
 
     qt_config->endGroup();

--- a/src/citra_qt/configuration/configure_layout.cpp
+++ b/src/citra_qt/configuration/configure_layout.cpp
@@ -20,24 +20,44 @@ ConfigureLayout::ConfigureLayout(QWidget* parent)
 
     ui->layout_group->setEnabled(!Settings::values.custom_layout);
     ui->layout_group->setEnabled(!Settings::values.new_custom_layout);
+    ui->large_screen_proportion->setEnabled(
+        (Settings::values.layout_option.GetValue() == Settings::LayoutOption::LargeScreen));
+    connect(ui->layout_combobox,
+            static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+            [this](int currentIndex) {
+                ui->large_screen_proportion->setEnabled(
+                    currentIndex == (uint)(Settings::LayoutOption::LargeScreen));
+            });
 
     ui->custom_layout_group->setEnabled(
         (Settings::values.layout_option.GetValue() == Settings::LayoutOption::CustomLayout));
     connect(ui->layout_combobox,
             static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
             [this](int currentIndex) {
-                ui->custom_layout_group->setEnabled(ui->layout_combobox->currentIndex() ==
+                ui->custom_layout_group->setEnabled(currentIndex ==
                                                     (uint)(Settings::LayoutOption::CustomLayout));
             });
 
-    ui->large_screen_proportion->setEnabled(
-        (Settings::values.layout_option.GetValue() == Settings::LayoutOption::LargeScreen));
+    ui->screen_top_leftright_padding->setEnabled(Settings::values.screen_top_stretch.GetValue());
+    connect(ui->screen_top_stretch, static_cast<void (QCheckBox::*)(int)>(&QCheckBox::stateChanged),
+            this,
+            [this](bool checkState) { ui->screen_top_leftright_padding->setEnabled(checkState); });
+    ui->screen_top_topbottom_padding->setEnabled(Settings::values.screen_top_stretch.GetValue());
+    connect(ui->screen_top_stretch, static_cast<void (QCheckBox::*)(int)>(&QCheckBox::stateChanged),
+            this,
+            [this](bool checkState) { ui->screen_top_topbottom_padding->setEnabled(checkState); });
+    ui->screen_bottom_leftright_padding->setEnabled(
+        Settings::values.screen_bottom_topbottom_padding.GetValue());
     connect(
-        ui->layout_combobox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
-        this, [this](int currentIndex) {
-            ui->large_screen_proportion->setEnabled(ui->layout_combobox->currentIndex() ==
-                                                    (uint)(Settings::LayoutOption::LargeScreen));
-        });
+        ui->screen_bottom_stretch, static_cast<void (QCheckBox::*)(int)>(&QCheckBox::stateChanged),
+        this,
+        [this](bool checkState) { ui->screen_bottom_leftright_padding->setEnabled(checkState); });
+    ui->screen_bottom_topbottom_padding->setEnabled(
+        Settings::values.screen_bottom_topbottom_padding.GetValue());
+    connect(
+        ui->screen_bottom_stretch, static_cast<void (QCheckBox::*)(int)>(&QCheckBox::stateChanged),
+        this,
+        [this](bool checkState) { ui->screen_bottom_topbottom_padding->setEnabled(checkState); });
 
     connect(ui->bg_button, &QPushButton::clicked, this, [this] {
         const QColor new_bg_color = QColorDialog::getColor(bg_color);
@@ -67,6 +87,7 @@ void ConfigureLayout::SetConfiguration() {
     ui->toggle_swap_screen->setChecked(Settings::values.swap_screen.GetValue());
     ui->toggle_upright_screen->setChecked(Settings::values.upright_screen.GetValue());
     ui->large_screen_proportion->setValue(Settings::values.large_screen_proportion.GetValue());
+
     ui->custom_top_x->setValue(Settings::values.custom_top_x.GetValue());
     ui->custom_top_y->setValue(Settings::values.custom_top_y.GetValue());
     ui->custom_top_width->setValue(Settings::values.custom_top_width.GetValue());
@@ -77,6 +98,16 @@ void ConfigureLayout::SetConfiguration() {
     ui->custom_bottom_height->setValue(Settings::values.custom_bottom_height.GetValue());
     ui->new_custom_second_layer_opacity->setValue(
         Settings::values.new_custom_second_layer_opacity.GetValue());
+    ui->screen_top_stretch->setChecked(Settings::values.screen_top_stretch.GetValue());
+    ui->screen_top_leftright_padding->setValue(
+        Settings::values.screen_top_leftright_padding.GetValue());
+    ui->screen_top_topbottom_padding->setValue(
+        Settings::values.screen_top_topbottom_padding.GetValue());
+    ui->screen_bottom_stretch->setChecked(Settings::values.screen_bottom_stretch.GetValue());
+    ui->screen_bottom_leftright_padding->setValue(
+        Settings::values.screen_bottom_leftright_padding.GetValue());
+    ui->screen_bottom_topbottom_padding->setValue(
+        Settings::values.screen_bottom_topbottom_padding.GetValue());
     bg_color =
         QColor::fromRgbF(Settings::values.bg_red.GetValue(), Settings::values.bg_green.GetValue(),
                          Settings::values.bg_blue.GetValue());
@@ -102,6 +133,13 @@ void ConfigureLayout::ApplyConfiguration() {
     Settings::values.custom_bottom_width = ui->custom_bottom_width->value();
     Settings::values.custom_bottom_height = ui->custom_bottom_height->value();
     Settings::values.new_custom_second_layer_opacity = ui->new_custom_second_layer_opacity->value();
+
+    Settings::values.screen_top_stretch = ui->screen_top_stretch->checkState();
+    Settings::values.screen_top_leftright_padding = ui->screen_top_leftright_padding->value();
+    Settings::values.screen_top_topbottom_padding = ui->screen_top_topbottom_padding->value();
+    Settings::values.screen_bottom_stretch = ui->screen_bottom_stretch->checkState();
+    Settings::values.screen_bottom_leftright_padding = ui->screen_bottom_leftright_padding->value();
+    Settings::values.screen_bottom_topbottom_padding = ui->screen_bottom_topbottom_padding->value();
 
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.layout_option, ui->layout_combobox);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.swap_screen, ui->toggle_swap_screen,

--- a/src/citra_qt/configuration/configure_layout.cpp
+++ b/src/citra_qt/configuration/configure_layout.cpp
@@ -29,6 +29,17 @@ ConfigureLayout::ConfigureLayout(QWidget* parent)
                     currentIndex == (uint)(Settings::LayoutOption::LargeScreen));
             });
 
+    ui->single_screen_layout_config_group->setEnabled(
+        (Settings::values.layout_option.GetValue() == Settings::LayoutOption::SingleScreen) ||
+        (Settings::values.layout_option.GetValue() == Settings::LayoutOption::SeparateWindows));
+    connect(ui->layout_combobox,
+            static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+            [this](int currentIndex) {
+                ui->single_screen_layout_config_group->setEnabled(
+                    (currentIndex == (uint)(Settings::LayoutOption::SingleScreen)) ||
+                    (currentIndex == (uint)(Settings::LayoutOption::SeparateWindows)));
+            });
+
     ui->custom_layout_group->setEnabled(
         (Settings::values.layout_option.GetValue() == Settings::LayoutOption::CustomLayout));
     connect(ui->layout_combobox,

--- a/src/citra_qt/configuration/configure_layout.ui
+++ b/src/citra_qt/configuration/configure_layout.ui
@@ -22,6 +22,9 @@
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
     <widget class="QGroupBox" name="layout_group">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
      <property name="title">
       <string>Screens</string>
      </property>
@@ -408,7 +411,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="separate_window_config_group">
+    <widget class="QGroupBox" name="single_screen_layout_config_group">
      <property name="minimumSize">
       <size>
        <width>0</width>

--- a/src/citra_qt/configuration/configure_layout.ui
+++ b/src/citra_qt/configuration/configure_layout.ui
@@ -177,219 +177,394 @@
         </layout>
        </widget>
       </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="custom_layout_group">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="title">
+      <string>Custom Layout</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_5">
       <item>
-       <widget class="QGroupBox" name="custom_layout_group">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="title">
-         <string>Custom Layout</string>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout_5">
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_4">
-           <item>
-            <widget class="QGroupBox" name="gb_top_screen">
-             <property name="title">
-              <string>Top Screen</string>
-             </property>
-             <layout class="QGridLayout" name="gridLayout_2">
-              <item row="0" column="0">
-               <widget class="QLabel" name="lb_top_x">
-                <property name="text">
-                 <string>X Position</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QSpinBox" name="custom_top_x">
-                <property name="buttonSymbols">
-                 <enum>QAbstractSpinBox::NoButtons</enum>
-                </property>
-                <property name="maximum">
-                 <number>2147483647</number>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="lb_top_y">
-                <property name="text">
-                 <string>Y Position</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QSpinBox" name="custom_top_y">
-                <property name="buttonSymbols">
-                 <enum>QAbstractSpinBox::NoButtons</enum>
-                </property>
-                <property name="maximum">
-                 <number>2147483647</number>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="lb_top_width">
-                <property name="text">
-                 <string>Width</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QSpinBox" name="custom_top_width">
-                <property name="buttonSymbols">
-                 <enum>QAbstractSpinBox::NoButtons</enum>
-                </property>
-                <property name="maximum">
-                 <number>2147483647</number>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0">
-               <widget class="QLabel" name="lb_top_height">
-                <property name="text">
-                 <string>Height</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="1">
-               <widget class="QSpinBox" name="custom_top_height">
-                <property name="buttonSymbols">
-                 <enum>QAbstractSpinBox::NoButtons</enum>
-                </property>
-                <property name="maximum">
-                 <number>2147483647</number>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QGroupBox" name="gb_bottom_screen">
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="title">
-              <string>Bottom Screen</string>
-             </property>
-             <layout class="QGridLayout" name="gridLayout">
-              <item row="0" column="0">
-               <widget class="QLabel" name="lb_bottom_x">
-                <property name="text">
-                 <string>X Position</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QSpinBox" name="custom_bottom_x">
-                <property name="buttonSymbols">
-                 <enum>QAbstractSpinBox::NoButtons</enum>
-                </property>
-                <property name="maximum">
-                 <number>2147483647</number>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="lb_bottom_y">
-                <property name="text">
-                 <string>Y Position</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QSpinBox" name="custom_bottom_y">
-                <property name="buttonSymbols">
-                 <enum>QAbstractSpinBox::NoButtons</enum>
-                </property>
-                <property name="maximum">
-                 <number>2147483647</number>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="lb_bottom_width">
-                <property name="text">
-                 <string>Width</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QSpinBox" name="custom_bottom_width">
-                <property name="buttonSymbols">
-                 <enum>QAbstractSpinBox::NoButtons</enum>
-                </property>
-                <property name="maximum">
-                 <number>2147483647</number>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0">
-               <widget class="QLabel" name="lb_bottom_height">
-                <property name="text">
-                 <string>Height</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="1">
-               <widget class="QSpinBox" name="custom_bottom_height">
-                <property name="buttonSymbols">
-                 <enum>QAbstractSpinBox::NoButtons</enum>
-                </property>
-                <property name="maximum">
-                 <number>2147483647</number>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_2">
-           <item>
-            <widget class="QLabel" name="label_2">
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <item>
+         <widget class="QGroupBox" name="gb_top_screen">
+          <property name="title">
+           <string>Top Screen</string>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_2">
+           <item row="0" column="0">
+            <widget class="QLabel" name="lb_top_x">
              <property name="text">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;NOTE: Values are in pixels starting from the top left corner of the display. Positive numbers only.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              <string>X Position</string>
              </property>
             </widget>
            </item>
-          </layout>
-         </item>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_3">
-           <item>
-            <widget class="QLabel" name="lb_opacity_second_layer">
-             <property name="text">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Bottom Screen Opacity % (OpenGL Only)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QSpinBox" name="new_custom_second_layer_opacity">
+           <item row="0" column="1">
+            <widget class="QSpinBox" name="custom_top_x">
              <property name="buttonSymbols">
-              <enum>QAbstractSpinBox::PlusMinus</enum>
+              <enum>QAbstractSpinBox::NoButtons</enum>
              </property>
-             <property name="minimum">
-              <number>10</number>
+             <property name="suffix">
+              <string>px</string>
              </property>
              <property name="maximum">
-              <number>100</number>
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="lb_top_y">
+             <property name="text">
+              <string>Y Position</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QSpinBox" name="custom_top_y">
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="suffix">
+              <string>px</string>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="lb_top_width">
+             <property name="text">
+              <string>Width</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QSpinBox" name="custom_top_width">
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="suffix">
+              <string>px</string>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="lb_top_height">
+             <property name="text">
+              <string>Height</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QSpinBox" name="custom_top_height">
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="suffix">
+              <string>px</string>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
              </property>
             </widget>
            </item>
           </layout>
-         </item>
-        </layout>
-       </widget>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="gb_bottom_screen">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="title">
+           <string>Bottom Screen</string>
+          </property>
+          <layout class="QGridLayout" name="gridLayout">
+           <item row="0" column="0">
+            <widget class="QLabel" name="lb_bottom_x">
+             <property name="text">
+              <string>X Position</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QSpinBox" name="custom_bottom_x">
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="suffix">
+              <string>px</string>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="lb_bottom_y">
+             <property name="text">
+              <string>Y Position</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QSpinBox" name="custom_bottom_y">
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="suffix">
+              <string>px</string>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="lb_bottom_width">
+             <property name="text">
+              <string>Width</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QSpinBox" name="custom_bottom_width">
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="suffix">
+              <string>px</string>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="lb_bottom_height">
+             <property name="text">
+              <string>Height</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QSpinBox" name="custom_bottom_height">
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="suffix">
+              <string>px</string>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QLabel" name="lb_opacity_second_layer">
+          <property name="text">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Bottom Screen Opacity % (OpenGL Only)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="new_custom_second_layer_opacity">
+          <property name="buttonSymbols">
+           <enum>QAbstractSpinBox::PlusMinus</enum>
+          </property>
+          <property name="minimum">
+           <number>10</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="separate_window_config_group">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="title">
+      <string>Single Screen Layout</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_5">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <item>
+         <widget class="QGroupBox" name="gb_top_screen_2">
+          <property name="title">
+           <string>Top Screen</string>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_2">
+           <item row="0" column="0">
+            <widget class="QLabel" name="lb_top_stretch">
+             <property name="text">
+              <string>Stretch</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QSpinBox" name="screen_top_leftright_padding">
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="suffix">
+              <string>px</string>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="lb_top_leftright_padding">
+             <property name="text">
+              <string>Left/Right Padding</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="lb_top_topbottom_padding">
+             <property name="text">
+              <string>Top/Bottom Padding</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QSpinBox" name="screen_top_topbottom_padding">
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="suffix">
+              <string>px</string>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QCheckBox" name="screen_top_stretch">
+             <property name="text">
+              <string notr="true"/>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="gb_bottom_screen">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="title">
+           <string>Bottom Screen</string>
+          </property>
+          <layout class="QGridLayout" name="gridLayout">
+           <item row="1" column="0">
+            <widget class="QLabel" name="lb_bottom_leftright_padding">
+             <property name="text">
+              <string>Left/Right Padding</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="lb_bottom_topbottom_padding">
+             <property name="text">
+              <string>Top/Bottom Padding</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QSpinBox" name="screen_bottom_leftright_padding">
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="suffix">
+              <string>px</string>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QSpinBox" name="screen_bottom_topbottom_padding">
+             <property name="buttonSymbols">
+              <enum>QAbstractSpinBox::NoButtons</enum>
+             </property>
+             <property name="suffix">
+              <string>px</string>
+             </property>
+             <property name="maximum">
+              <number>2147483647</number>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="lb_bottom_stretch">
+             <property name="text">
+              <string>Stretch</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QCheckBox" name="screen_bottom_stretch">
+             <property name="text">
+              <string notr="true"/>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Note: These settings affect the Single Screen and Separate Windows layouts</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
 >>>>>>> b2607fd99 (citra_qt: Remove scroll bar from Layout and Enhancements tabs):src/citra_qt/configuration/configure_layout.ui

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -344,6 +344,11 @@ void GMainWindow::InitializeWidgets() {
     secondary_window->hide();
     secondary_window->setParent(nullptr);
 
+    action_secondary_fullscreen = new QAction(secondary_window);
+    action_secondary_toggle_screen = new QAction(secondary_window);
+    action_secondary_swap_screen = new QAction(secondary_window);
+    action_secondary_rotate_screen = new QAction(secondary_window);
+
     game_list = new GameList(*play_time_manager, this);
     ui->horizontalLayout->addWidget(game_list);
 
@@ -600,7 +605,7 @@ void GMainWindow::InitializeSaveStateMenuActions() {
     UpdateSaveStates();
 }
 
-void GMainWindow::InitializeHotkeys() {
+void GMainWindow::InitializeHotkeys() { // TODO: This code kind of sucks
     hotkey_registry.LoadHotkeys();
 
     const QString main_window = QStringLiteral("Main Window");
@@ -643,28 +648,32 @@ void GMainWindow::InitializeHotkeys() {
     link_action_shortcut(ui->action_Show_Room, QStringLiteral("Multiplayer Show Current Room"));
     link_action_shortcut(ui->action_Leave_Room, QStringLiteral("Multiplayer Leave Room"));
 
-    const auto add_secondary_window_hotkey = [this](QKeySequence hotkey, const char* slot) {
+    const auto add_secondary_window_hotkey = [this](QAction* action, QKeySequence hotkey,
+                                                    const char* slot) {
         // This action will fire specifically when secondary_window is in focus
-        QAction* secondary_window_action = new QAction(secondary_window);
-        secondary_window_action->setShortcut(hotkey);
-
-        connect(secondary_window_action, SIGNAL(triggered()), this, slot);
-        secondary_window->addAction(secondary_window_action);
+        action->setShortcut(hotkey);
+        disconnect(action, SIGNAL(triggered()), this, slot);
+        connect(action, SIGNAL(triggered()), this, slot);
+        secondary_window->addAction(action);
     };
 
     // Use the same fullscreen hotkey as the main window
     const auto fullscreen_hotkey = hotkey_registry.GetKeySequence(main_window, fullscreen);
-    add_secondary_window_hotkey(fullscreen_hotkey, SLOT(ToggleSecondaryFullscreen()));
+    add_secondary_window_hotkey(action_secondary_fullscreen, fullscreen_hotkey,
+                                SLOT(ToggleSecondaryFullscreen()));
 
     const auto toggle_screen_hotkey =
         hotkey_registry.GetKeySequence(main_window, toggle_screen_layout);
-    add_secondary_window_hotkey(toggle_screen_hotkey, SLOT(ToggleScreenLayout()));
+    add_secondary_window_hotkey(action_secondary_toggle_screen, toggle_screen_hotkey,
+                                SLOT(ToggleScreenLayout()));
 
     const auto swap_screen_hotkey = hotkey_registry.GetKeySequence(main_window, swap_screens);
-    add_secondary_window_hotkey(swap_screen_hotkey, SLOT(TriggerSwapScreens()));
+    add_secondary_window_hotkey(action_secondary_swap_screen, swap_screen_hotkey,
+                                SLOT(TriggerSwapScreens()));
 
     const auto rotate_screen_hotkey = hotkey_registry.GetKeySequence(main_window, rotate_screens);
-    add_secondary_window_hotkey(rotate_screen_hotkey, SLOT(TriggerRotateScreens()));
+    add_secondary_window_hotkey(action_secondary_rotate_screen, rotate_screen_hotkey,
+                                SLOT(TriggerRotateScreens()));
 
     const auto connect_shortcut = [&](const QString& action_name, const auto& function) {
         const auto* hotkey = hotkey_registry.GetHotkey(main_window, action_name, this);

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -409,6 +409,12 @@ private:
     u32 newest_slot;
     u64 newest_slot_time;
 
+    // Secondary window actions
+    QAction* action_secondary_fullscreen;
+    QAction* action_secondary_toggle_screen;
+    QAction* action_secondary_swap_screen;
+    QAction* action_secondary_rotate_screen;
+
     QTranslator translator;
 
     // stores default icon theme search paths for the platform

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -512,6 +512,13 @@ struct Values {
     Setting<u16> custom_bottom_height{240, "custom_bottom_height"};
     Setting<u16> new_custom_second_layer_opacity{100, "new_custom_second_layer_opacity"};
 
+    SwitchableSetting<bool> screen_top_stretch{false, "screen_top_stretch"};
+    Setting<u16> screen_top_leftright_padding{0, "screen_top_leftright_padding"};
+    Setting<u16> screen_top_topbottom_padding{0, "screen_top_topbottom_padding"};
+    SwitchableSetting<bool> screen_bottom_stretch{false, "screen_bottom_stretch"};
+    Setting<u16> screen_bottom_leftright_padding{0, "screen_bottom_leftright_padding"};
+    Setting<u16> screen_bottom_topbottom_padding{0, "screen_bottom_topbottom_padding"};
+
     SwitchableSetting<float> bg_red{0.f, "bg_red"};
     SwitchableSetting<float> bg_green{0.f, "bg_green"};
     SwitchableSetting<float> bg_blue{0.f, "bg_blue"};

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -173,9 +173,20 @@ FramebufferLayout SingleFrameLayout(u32 width, u32 height, bool swapped, bool up
         emulation_aspect_ratio = (swapped) ? BOT_SCREEN_ASPECT_RATIO : TOP_SCREEN_ASPECT_RATIO;
     }
 
+    const bool stretched = (Settings::values.screen_top_stretch.GetValue() && !swapped) ||
+                           (Settings::values.screen_bottom_stretch.GetValue() && swapped);
     float window_aspect_ratio = static_cast<float>(height) / width;
 
-    if (window_aspect_ratio < emulation_aspect_ratio) {
+    if (stretched) {
+        top_screen = {Settings::values.screen_top_leftright_padding.GetValue(),
+                      Settings::values.screen_top_topbottom_padding.GetValue(),
+                      width - Settings::values.screen_top_leftright_padding.GetValue(),
+                      height - Settings::values.screen_top_topbottom_padding.GetValue()};
+        bot_screen = {Settings::values.screen_bottom_leftright_padding.GetValue(),
+                      Settings::values.screen_bottom_topbottom_padding.GetValue(),
+                      width - Settings::values.screen_bottom_leftright_padding.GetValue(),
+                      height - Settings::values.screen_bottom_topbottom_padding.GetValue()};
+    } else if (window_aspect_ratio < emulation_aspect_ratio) {
         top_screen =
             top_screen.TranslateX((screen_window_area.GetWidth() - top_screen.GetWidth()) / 2);
         bot_screen =


### PR DESCRIPTION
This pull request adds configuration options for controlling the appearance of the Single Screen and Separate Windows layout options. The pull request also restructures the Layout tab of the configuration menu.

Ported from Lime3DS.