### PR TITLE
Reimplement Frame Skip functionality

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/IntSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/IntSetting.kt
@@ -41,6 +41,7 @@ enum class IntSetting(
     VSYNC("use_vsync_new", Settings.SECTION_RENDERER, 1),
     DEBUG_RENDERER("renderer_debug", Settings.SECTION_DEBUG, 0),
     TEXTURE_FILTER("texture_filter", Settings.SECTION_RENDERER, 0),
+    FRAME_SKIP("frame_skip", Settings.SECTION_CORE, 0),
     USE_FRAME_LIMIT("use_frame_limit", Settings.SECTION_RENDERER, 1),
     DELAY_RENDER_THREAD_US("delay_game_render_thread_us", Settings.SECTION_RENDERER, 0),
     USE_ARTIC_BASE_CONTROLLER("use_artic_base_controller", Settings.SECTION_CONTROLS, 0);

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -175,17 +175,6 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
         settingsActivity.setToolbarTitle(settingsActivity.getString(R.string.preferences_general))
         sl.apply {
             add(
-                SingleChoiceSetting(
-                    IntSetting.FRAME_SKIP,
-                    R.string.frame_skip_name,
-                    R.string.frame_skip_description,
-                    R.array.frameSkipNames,
-                    R.array.frameSkipValues,
-                    IntSetting.FRAME_SKIP.key,
-                    IntSetting.FRAME_SKIP.defaultValue
-                )
-            )
-            add(
                 SwitchSetting(
                     IntSetting.USE_FRAME_LIMIT,
                     R.string.frame_limit_enable,
@@ -204,6 +193,17 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     "%",
                     IntSetting.FRAME_LIMIT.key,
                     IntSetting.FRAME_LIMIT.defaultValue.toFloat()
+                )
+            )
+            add(
+                SingleChoiceSetting(
+                    IntSetting.FRAME_SKIP,
+                    R.string.frame_skip_name,
+                    R.string.frame_skip_description,
+                    R.array.frameSkipNames,
+                    R.array.frameSkipValues,
+                    IntSetting.FRAME_SKIP.key,
+                    IntSetting.FRAME_SKIP.defaultValue
                 )
             )
         }

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -175,6 +175,17 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
         settingsActivity.setToolbarTitle(settingsActivity.getString(R.string.preferences_general))
         sl.apply {
             add(
+                SingleChoiceSetting(
+                    IntSetting.FRAME_SKIP,
+                    R.string.frame_skip_name,
+                    R.string.frame_skip_description,
+                    R.array.frameSkipNames,
+                    R.array.frameSkipValues,
+                    IntSetting.FRAME_SKIP.key,
+                    IntSetting.FRAME_SKIP.defaultValue
+                )
+            )
+            add(
                 SwitchSetting(
                     IntSetting.USE_FRAME_LIMIT,
                     R.string.frame_limit_enable,

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -962,7 +962,7 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                 SwitchSetting(
                     IntSetting.NEW_3DS,
                     R.string.new_3ds,
-                    0,
+                    R.string.new_3ds_description,
                     IntSetting.NEW_3DS.key,
                     IntSetting.NEW_3DS.defaultValue
                 )

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -133,6 +133,7 @@ void Config::ReadValues() {
     // Core
     ReadSetting("Core", Settings::values.use_cpu_jit);
     ReadSetting("Core", Settings::values.cpu_clock_percentage);
+    ReadSetting("Core", Settings::values.frame_skip);
 
     // Renderer
     Settings::values.use_gles = sdl2_config->GetBoolean("Renderer", "use_gles", true);

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -101,7 +101,7 @@ use_cpu_jit =
 cpu_clock_percentage =
 
 # The applied frameskip amount. Must be a power of two.
-# 0 (default): No frameskip, 1: x2 frameskip, 2: x4 frameskip, 3: x8 frameskip, etc.
+# 0 (default): No frameskip, 1: x2 frameskip, 2: x4 frameskip, 3: x8 frameskip, x16 frameskip.
 frame_skip =
 
 [Renderer]

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -100,6 +100,10 @@ use_cpu_jit =
 # Range is any positive integer (but we suspect 25 - 400 is a good idea) Default is 100
 cpu_clock_percentage =
 
+# The applied frameskip amount. Must be a power of two.
+# 0 (default): No frameskip, 1: x2 frameskip, 2: x4 frameskip, 3: x8 frameskip, etc.
+frame_skip =
+
 [Renderer]
 # Whether to render using OpenGL
 # 1: OpenGL ES (default), 2: Vulkan

--- a/src/android/app/src/main/res/values-es/strings.xml
+++ b/src/android/app/src/main/res/values-es/strings.xml
@@ -157,6 +157,7 @@
     <!-- System settings strings -->
     <string name="username">Nombre de usuario/a</string>
     <string name="new_3ds">Modo New 3DS</string>
+    <string name="new_3ds_description">El New 3DS tiene una memoria y un procesador diferentes, y algunos juegos solo pueden iniciarse en el New 3DS.</string>
     <string name="clock">Reloj</string>
     <string name="init_time">Tiempo de compensación</string>
     <string name="init_time_description">Si el reloj está en \"Reloj emulado\", ésto cambia la fecha y hora de inicio.</string>

--- a/src/android/app/src/main/res/values/arrays.xml
+++ b/src/android/app/src/main/res/values/arrays.xml
@@ -183,6 +183,20 @@
         <item>5</item>
     </integer-array>
 
+    <string-array name="frameSkipNames">
+        <item>@string/disabled</item>
+        <item>@string/x2</item>
+        <item>@string/x4</item>
+        <item>@string/x8</item>
+    </string-array>
+
+    <integer-array name="frameSkipValues">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+    </integer-array>
+
     <string-array name="themeModeEntries">
         <item>@string/theme_mode_follow_system</item>
         <item>@string/theme_mode_light</item>

--- a/src/android/app/src/main/res/values/arrays.xml
+++ b/src/android/app/src/main/res/values/arrays.xml
@@ -188,6 +188,7 @@
         <item>@string/x2</item>
         <item>@string/x4</item>
         <item>@string/x8</item>
+        <item>@string/x16</item>
     </string-array>
 
     <integer-array name="frameSkipValues">
@@ -195,6 +196,7 @@
         <item>1</item>
         <item>2</item>
         <item>3</item>
+        <item>4</item>
     </integer-array>
 
     <string-array name="themeModeEntries">

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -178,6 +178,7 @@
     <!-- System settings strings -->
     <string name="username">Username</string>
     <string name="new_3ds">New 3DS Mode</string>
+    <string name="new_3ds_description">The New 3DS has different memory and processor, and some games can only start on the New 3DS.</string>
     <string name="lle_applets">Use LLE Applets (if installed)</string>
     <string name="clock">Clock</string>
     <string name="init_time">Offset Time</string>
@@ -232,7 +233,7 @@
     <string name="asynchronous_gpu">Enable asynchronous GPU emulation</string>
     <string name="asynchronous_gpu_description">Uses a separate thread to emulate the GPU asynchronously. When enabled, performance will be improved.</string>
     <string name="frame_skip_name">Frame Skip</string>
-    <string name="frame_skip_description">The number of frames to skip.\n\nWARNING: Results may vary depending on using the Vulkan or OpenGL renderer. If set too high, the screen may not render at all. Use with caution.</string>
+    <string name="frame_skip_description">The number of frames to skip. It may cause emulation speed desync issues.</string>
     <string name="frame_limit_enable">Limit Speed</string>
     <string name="frame_limit_enable_description">When enabled, emulation speed will be limited to a specified percentage of normal speed.</string>
     <string name="frame_limit_slider">Limit Speed Percent</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -231,6 +231,8 @@
     <string name="shaders_accurate_mul_description">Uses more accurate multiplication in hardware shaders, which may fix some graphical bugs. When enabled, performance will be reduced.</string>
     <string name="asynchronous_gpu">Enable asynchronous GPU emulation</string>
     <string name="asynchronous_gpu_description">Uses a separate thread to emulate the GPU asynchronously. When enabled, performance will be improved.</string>
+    <string name="frame_skip_name">Frame Skip</string>
+    <string name="frame_skip_description">The number of frames to skip.\n\nWARNING: Results may vary depending on using the Vulkan or OpenGL renderer. If set too high, the screen may not render at all. Use with caution.</string>
     <string name="frame_limit_enable">Limit Speed</string>
     <string name="frame_limit_enable_description">When enabled, emulation speed will be limited to a specified percentage of normal speed.</string>
     <string name="frame_limit_slider">Limit Speed Percent</string>
@@ -555,6 +557,12 @@
     <string name="scaleforce">ScaleForce</string>
     <string name="xbrz">xBRZ</string>
     <string name="mmpx">MMPX</string>
+
+    <!-- Frame skip names -->
+    <string name="disabled">Disabled</string>
+    <string name="x2">x2</string>
+    <string name="x4">x4</string>
+    <string name="x8">x8</string>
 
     <!-- Sound output modes -->
     <string name="mono">Mono</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -233,7 +233,7 @@
     <string name="asynchronous_gpu">Enable asynchronous GPU emulation</string>
     <string name="asynchronous_gpu_description">Uses a separate thread to emulate the GPU asynchronously. When enabled, performance will be improved.</string>
     <string name="frame_skip_name">Frame Skip</string>
-    <string name="frame_skip_description">The number of frames to skip. It may cause emulation speed desync issues.</string>
+    <string name="frame_skip_description">The number of frames to skip. It may cause emulation desynchronization issues. May not work well with Realtime Audio enabled.</string>
     <string name="frame_limit_enable">Limit Speed</string>
     <string name="frame_limit_enable_description">When enabled, emulation speed will be limited to a specified percentage of normal speed.</string>
     <string name="frame_limit_slider">Limit Speed Percent</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -564,6 +564,7 @@
     <string name="x2">x2</string>
     <string name="x4">x4</string>
     <string name="x8">x8</string>
+    <string name="x16">x16</string>
 
     <!-- Sound output modes -->
     <string name="mono">Mono</string>

--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -130,6 +130,7 @@ void Config::ReadValues() {
     // Core
     ReadSetting("Core", Settings::values.use_cpu_jit);
     ReadSetting("Core", Settings::values.cpu_clock_percentage);
+    ReadSetting("Core", Settings::values.frame_skip);
 
     // Renderer
     ReadSetting("Renderer", Settings::values.graphics_api);

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -98,7 +98,7 @@ use_cpu_jit =
 cpu_clock_percentage =
 
 # The applied frameskip amount. Must be a power of two.
-# 0 (default): No frameskip, 1: x2 frameskip, 2: x4 frameskip, 3: x8 frameskip, etc.
+# 0 (default): No frameskip, 1: x2 frameskip, 2: x4 frameskip, 3: x8 frameskip, x16 frameskip.
 frame_skip =
 
 [Renderer]

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -97,6 +97,10 @@ use_cpu_jit =
 # Range is any positive integer (but we suspect 25 - 400 is a good idea) Default is 100
 cpu_clock_percentage =
 
+# The applied frameskip amount. Must be a power of two.
+# 0 (default): No frameskip, 1: x2 frameskip, 2: x4 frameskip, 3: x8 frameskip, etc.
+frame_skip =
+
 [Renderer]
 # Whether to render using OpenGL or Software
 # 0: Software, 1: OpenGL (default), 2: Vulkan

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -457,6 +457,7 @@ void Config::ReadCoreValues() {
     qt_config->beginGroup(QStringLiteral("Core"));
 
     ReadGlobalSetting(Settings::values.cpu_clock_percentage);
+    ReadGlobalSetting(Settings::values.frame_skip);
 
     if (global) {
         ReadBasicSetting(Settings::values.use_cpu_jit);
@@ -1031,6 +1032,7 @@ void Config::SaveCoreValues() {
     qt_config->beginGroup(QStringLiteral("Core"));
 
     WriteGlobalSetting(Settings::values.cpu_clock_percentage);
+    WriteGlobalSetting(Settings::values.frame_skip);
 
     if (global) {
         WriteBasicSetting(Settings::values.use_cpu_jit);

--- a/src/citra_qt/configuration/configure_general.cpp
+++ b/src/citra_qt/configuration/configure_general.cpp
@@ -119,6 +119,13 @@ void ConfigureGeneral::SetConfiguration() {
         }
         ConfigurationShared::SetHighlight(ui->widget_screenshot,
                                           !UISettings::values.screenshot_path.UsingGlobal());
+
+        // Frameskip
+        ConfigurationShared::SetPerGameSetting(ui->frame_skip_combobox,
+                                               &Settings::values.frame_skip);
+        ConfigurationShared::SetHighlight(ui->widget_frame_skip,
+                                          !Settings::values.frame_skip.UsingGlobal());
+
         ConfigurationShared::SetHighlight(ui->emulation_speed_layout,
                                           !Settings::values.frame_limit.UsingGlobal());
         ConfigurationShared::SetHighlight(ui->widget_region,
@@ -129,6 +136,8 @@ void ConfigureGeneral::SetConfiguration() {
                              : static_cast<int>(Settings::values.region_value.GetValue()) +
                                    ConfigurationShared::USE_GLOBAL_OFFSET + 1);
     } else {
+        ui->frame_skip_combobox->setCurrentIndex(
+            static_cast<int>(Settings::values.frame_skip.GetValue()));
         // The first item is "auto-select" with actual value -1, so plus one here will do the trick
         ui->region_combobox->setCurrentIndex(Settings::values.region_value.GetValue() + 1);
     }
@@ -173,6 +182,8 @@ void ConfigureGeneral::ApplyConfiguration() {
         &UISettings::values.screenshot_path, ui->screenshot_combo,
         [this](s32) { return ui->screenshot_dir_path->text().toStdString(); });
 
+    ConfigurationShared::ApplyPerGameSetting(&Settings::values.frame_skip, ui->frame_skip_combobox);
+
     if (Settings::IsConfiguringGlobal()) {
         UISettings::values.confirm_before_closing = ui->toggle_check_exit->isChecked();
         UISettings::values.pause_when_in_background = ui->toggle_background_pause->isChecked();
@@ -193,6 +204,7 @@ void ConfigureGeneral::RetranslateUI() {
 
 void ConfigureGeneral::SetupPerGameUI() {
     if (Settings::IsConfiguringGlobal()) {
+        ui->widget_frame_skip->setEnabled(Settings::values.frame_skip.UsingGlobal());
         ui->region_combobox->setEnabled(Settings::values.region_value.UsingGlobal());
         ui->frame_limit->setEnabled(Settings::values.frame_limit.UsingGlobal());
         return;
@@ -214,6 +226,10 @@ void ConfigureGeneral::SetupPerGameUI() {
     ui->updateBox->setVisible(false);
     ui->button_reset_defaults->setVisible(false);
     ui->toggle_gamemode->setVisible(false);
+
+    ConfigurationShared::SetColoredComboBox(
+        ui->frame_skip_combobox, ui->widget_frame_skip,
+        static_cast<int>(Settings::values.frame_skip.GetValue(true)));
 
     ConfigurationShared::SetColoredComboBox(
         ui->region_combobox, ui->widget_region,

--- a/src/citra_qt/configuration/configure_general.ui
+++ b/src/citra_qt/configuration/configure_general.ui
@@ -107,7 +107,7 @@
            <item>
             <widget class="QLabel" name="frame_skip_label">
              <property name="toolTip">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The number of frames to skip.&lt;/p&gt;&lt;p&gt;WARNING: Results may vary depending on using the Vulkan or OpenGL renderer. If set too high, the screen may not render at all. Use with caution.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              <string>&lt;html&gt;&lt;body&gt;The number of frames to skip. It may cause emulation speed desync issues.&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="text">
               <string>Frame Skip</string>

--- a/src/citra_qt/configuration/configure_general.ui
+++ b/src/citra_qt/configuration/configure_general.ui
@@ -90,6 +90,58 @@
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <item>
+         <widget class="QWidget" name="widget_frame_skip" native="true">
+          <layout class="QHBoxLayout" name="frameskip_layout">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="frame_skip_label">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The number of frames to skip.&lt;/p&gt;&lt;p&gt;WARNING: Results may vary depending on using the Vulkan or OpenGL renderer. If set too high, the screen may not render at all. Use with caution.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="text">
+              <string>Frame Skip</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="frame_skip_combobox">
+             <item>
+              <property name="text">
+               <string>Disabled</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>x2</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>x4</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>x8</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
          <widget class="QWidget" name="widget_region" native="true">
           <layout class="QHBoxLayout" name="region_layout">
            <property name="leftMargin">
@@ -326,6 +378,7 @@
   <tabstop>toggle_hide_mouse</tabstop>
   <tabstop>toggle_update_check</tabstop>
   <tabstop>toggle_auto_update</tabstop>
+  <tabstop>frame_skip_combobox</tabstop>
   <tabstop>button_reset_defaults</tabstop>
  </tabstops>
  <resources/>

--- a/src/citra_qt/configuration/configure_general.ui
+++ b/src/citra_qt/configuration/configure_general.ui
@@ -205,6 +205,11 @@
                <string>x8</string>
               </property>
              </item>
+             <item>
+              <property name="text">
+               <string>x16</string>
+              </property>
+             </item>
             </widget>
            </item>
           </layout>

--- a/src/citra_qt/configuration/configure_general.ui
+++ b/src/citra_qt/configuration/configure_general.ui
@@ -107,7 +107,7 @@
            <item>
             <widget class="QLabel" name="frame_skip_label">
              <property name="toolTip">
-              <string>&lt;html&gt;&lt;body&gt;The number of frames to skip. It may cause emulation speed desync issues.&lt;/body&gt;&lt;/html&gt;</string>
+              <string>&lt;html&gt;&lt;body&gt;The number of frames to skip. It may cause emulation desynchronization issues. May not work well with Realtime Audio enabled.&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="text">
               <string>Frame Skip</string>

--- a/src/citra_qt/configuration/configure_general.ui
+++ b/src/citra_qt/configuration/configure_general.ui
@@ -104,43 +104,6 @@
            <property name="bottomMargin">
             <number>0</number>
            </property>
-           <item>
-            <widget class="QLabel" name="frame_skip_label">
-             <property name="toolTip">
-              <string>&lt;html&gt;&lt;body&gt;The number of frames to skip. It may cause emulation desynchronization issues. May not work well with Realtime Audio enabled.&lt;/body&gt;&lt;/html&gt;</string>
-             </property>
-             <property name="text">
-              <string>Frame Skip</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QComboBox" name="frame_skip_combobox">
-             <item>
-              <property name="text">
-               <string>Disabled</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>x2</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>x4</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>x8</string>
-              </property>
-             </item>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
         <item>
          <widget class="QWidget" name="widget_region" native="true">
           <layout class="QHBoxLayout" name="region_layout">
@@ -203,6 +166,43 @@
              <item>
               <property name="text">
                <string notr="true">TWN</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+           <item>
+            <widget class="QLabel" name="frame_skip_label">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;body&gt;The number of frames to skip. It may cause emulation desynchronization issues. May not work well with Realtime Audio enabled.&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="text">
+              <string>Frame Skip</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="frame_skip_combobox">
+             <item>
+              <property name="text">
+               <string>Disabled</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>x2</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>x4</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>x8</string>
               </property>
              </item>
             </widget>

--- a/src/citra_qt/configuration/configure_system.ui
+++ b/src/citra_qt/configuration/configure_system.ui
@@ -51,6 +51,9 @@
            <layout class="QGridLayout" name="gridLayout">
             <item row="1" column="0">
              <widget class="QCheckBox" name="toggle_new_3ds">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The New 3DS has different memory and processor, and some games can only start on the New 3DS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
               <property name="text">
                <string>Enable New 3DS Mode</string>
               </property>

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -83,6 +83,7 @@ void LogSettings() {
     LOG_INFO(Config, "Citra Configuration:");
     log_setting("Core_UseCpuJit", values.use_cpu_jit.GetValue());
     log_setting("Core_CPUClockPercentage", values.cpu_clock_percentage.GetValue());
+    log_setting("Core_FrameSkip", values.frame_skip.GetValue());
     log_setting("Controller_UseArticController", values.use_artic_base_controller.GetValue());
     log_setting("Renderer_UseGLES", values.use_gles.GetValue());
     log_setting("Renderer_GraphicsAPI", GetGraphicsAPIName(values.graphics_api.GetValue()));
@@ -181,6 +182,7 @@ void RestoreGlobalState(bool is_powered_on) {
     values.cpu_clock_percentage.SetGlobal(true);
     values.is_new_3ds.SetGlobal(true);
     values.lle_applets.SetGlobal(true);
+    values.frame_skip.SetGlobal(true);
 
     // Renderer
     values.graphics_api.SetGlobal(true);

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -543,6 +543,9 @@ struct Values {
     SwitchableSetting<bool> preload_textures{false, "preload_textures"};
     SwitchableSetting<bool> async_custom_loading{true, "async_custom_loading"};
 
+    // Tweaks
+    SwitchableSetting<u64> frame_skip{0, "frame_skip"};
+
     // Audio
     bool audio_muted;
     SwitchableSetting<AudioEmulation> audio_emulation{AudioEmulation::HLE, "audio_emulation"};

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -3,7 +3,9 @@
 // Refer to the license.txt file included.
 
 #include "common/archives.h"
+#include "common/common_types.h"
 #include "common/microprofile.h"
+#include "common/settings.h"
 #include "core/core.h"
 #include "core/core_timing.h"
 #include "core/hle/service/gsp/gsp_gpu.h"
@@ -24,6 +26,13 @@ constexpr VAddr VADDR_GPU = 0x1EF00000;
 
 MICROPROFILE_DEFINE(GPU_DisplayTransfer, "GPU", "DisplayTransfer", MP_RGB(100, 100, 255));
 MICROPROFILE_DEFINE(GPU_CmdlistProcessing, "GPU", "Cmdlist Processing", MP_RGB(100, 255, 100));
+
+/// True if the current frame was skipped
+bool g_skip_frame;
+/// Total number of frames drawn
+static u64 frame_count;
+/// True if the last frame was skipped
+static bool last_skip_frame;
 
 struct GPU::Impl {
     Core::Timing& timing;
@@ -51,6 +60,9 @@ struct GPU::Impl {
 GPU::GPU(Core::System& system, Frontend::EmuWindow& emu_window,
          Frontend::EmuWindow* secondary_window)
     : impl{std::make_unique<Impl>(system, emu_window, secondary_window)} {
+    frame_count = 0;
+    last_skip_frame = false;
+    g_skip_frame = false;
     impl->vblank_event = impl->timing.RegisterEvent(
         "GPU::VBlankCallback",
         [this](uintptr_t user_data, s64 cycles_late) { VBlankCallback(user_data, cycles_late); });
@@ -407,8 +419,22 @@ void GPU::MemoryTransfer() {
 }
 
 void GPU::VBlankCallback(std::uintptr_t user_data, s64 cycles_late) {
-    // Present renderered frame.
-    impl->renderer->SwapBuffers();
+    frame_count++;
+    last_skip_frame = g_skip_frame;
+    g_skip_frame = (frame_count & Settings::values.frame_skip.GetValue()) != 0;
+
+    // Swap buffers based on the frameskip mode, which is a little bit tricky. When
+    // a frame is being skipped, nothing is being rendered to the internal framebuffer(s).
+    // So, we should only swap frames if the last frame was rendered. The rules are:
+    //  - If frameskip == 0 (disabled), always swap buffers
+    //  - If frameskip == 1, swap buffers every other frame (starting from the first frame)
+    //  - If frameskip > 1, swap buffers every frameskip^n frames (starting from the second frame)
+    if ((((Settings::values.frame_skip.GetValue() != 1) ^ last_skip_frame) &&
+         last_skip_frame != g_skip_frame) ||
+        Settings::values.frame_skip.GetValue() == 0) {
+        // Present renderered frame.
+        impl->renderer->SwapBuffers();
+    }
 
     // Signal to GSP that GPU interrupt has occurred
     impl->signal_interrupt(Service::GSP::InterruptId::PDC0);


### PR DESCRIPTION
Brings back the frame skip functionality that was removed in 2017. May not work well with Realtime Audio enabled. Improvements by Citra Enhanced.