### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
           repo-name: llvm
           keys-asc: https://apt.llvm.org/llvm-snapshot.gpg.key
       - name: Get latest CMake and Ninja
-        uses: lukka/get-cmake@v3.30.3
+        uses: lukka/get-cmake@v3.30.4
         with:
           cmakeVersion: latest
           ninjaVersion: latest 
@@ -109,7 +109,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.target }}-
       - name: Get latest CMake and Ninja
-        uses: lukka/get-cmake@v3.30.3
+        uses: lukka/get-cmake@v3.30.4
         with:
           cmakeVersion: latest
           ninjaVersion: latest 
@@ -318,7 +318,7 @@ jobs:
           fi
           echo $GIT_TAG_NAME
       - name: Get latest CMake and Ninja
-        uses: lukka/get-cmake@v3.30.3
+        uses: lukka/get-cmake@v3.30.4
         with:
           cmakeVersion: latest
           ninjaVersion: latest 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[lukka/get-cmake](https://github.com/lukka/get-cmake)** published a new release **[v3.30.4](https://github.com/lukka/get-cmake/releases/tag/v3.30.4)** on 2024-10-02T10:07:21Z
