### PR TITLE
borked3ds_qt: Add OpenGLES settings configuration UI

### DIFF
--- a/src/borked3ds_qt/configuration/config.cpp
+++ b/src/borked3ds_qt/configuration/config.cpp
@@ -687,6 +687,7 @@ void Config::ReadRendererValues() {
 
     ReadGlobalSetting(Settings::values.graphics_api);
     ReadGlobalSetting(Settings::values.physical_device);
+    ReadGlobalSetting(Settings::values.use_gles);
     ReadGlobalSetting(Settings::values.spirv_shader_gen);
     ReadGlobalSetting(Settings::values.geometry_shader);
     ReadGlobalSetting(Settings::values.use_sample_shading);
@@ -1232,6 +1233,7 @@ void Config::SaveRendererValues() {
 
     WriteGlobalSetting(Settings::values.graphics_api);
     WriteGlobalSetting(Settings::values.physical_device);
+    WriteGlobalSetting(Settings::values.use_gles);
     WriteGlobalSetting(Settings::values.spirv_shader_gen);
     WriteGlobalSetting(Settings::values.geometry_shader);
     WriteGlobalSetting(Settings::values.use_sample_shading);

--- a/src/borked3ds_qt/configuration/configure_graphics.cpp
+++ b/src/borked3ds_qt/configuration/configure_graphics.cpp
@@ -173,6 +173,7 @@ void ConfigureGraphics::SetConfiguration() {
             static_cast<int>(Settings::values.texture_sampling.GetValue()));
     }
 
+    ui->toggle_use_gles->setChecked(Settings::values.use_gles.GetValue());
     ui->toggle_hw_shader->setChecked(Settings::values.use_hw_shader.GetValue());
     ui->toggle_accurate_mul->setChecked(Settings::values.shaders_accurate_mul.GetValue());
     ui->toggle_disk_shader_cache->setChecked(Settings::values.use_disk_shader_cache.GetValue());
@@ -209,6 +210,8 @@ void ConfigureGraphics::ApplyConfiguration() {
                                              ui->physical_device_combo);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.async_shader_compilation,
                                              ui->toggle_async_shaders, async_shader_compilation);
+    ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_gles, ui->toggle_use_gles,
+                                             use_gles);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.async_presentation,
                                              ui->toggle_async_present, async_presentation);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.skip_slow_draw,
@@ -315,6 +318,8 @@ void ConfigureGraphics::SetupPerGameUI() {
     ConfigurationShared::SetColoredTristate(ui->toggle_async_shaders,
                                             Settings::values.async_shader_compilation,
                                             async_shader_compilation);
+    ConfigurationShared::SetColoredTristate(ui->toggle_use_gles, Settings::values.use_gles,
+                                            use_gles);
     ConfigurationShared::SetColoredTristate(
         ui->toggle_async_present, Settings::values.async_presentation, async_presentation);
     ConfigurationShared::SetColoredTristate(ui->toggle_skip_slow_draw,
@@ -360,6 +365,7 @@ void ConfigureGraphics::SetPhysicalDeviceComboVisibility(int index) {
         effective_api = static_cast<Settings::GraphicsAPI>(index);
     }
 
+    ui->toggle_use_gles->setVisible(effective_api == Settings::GraphicsAPI::OpenGL);
     ui->physical_device_group->setVisible(effective_api == Settings::GraphicsAPI::Vulkan);
     ui->spirv_shader_gen->setVisible(effective_api == Settings::GraphicsAPI::Vulkan);
     ui->toggle_geometry_shader->setVisible(effective_api == Settings::GraphicsAPI::Vulkan);

--- a/src/borked3ds_qt/configuration/configure_graphics.h
+++ b/src/borked3ds_qt/configuration/configure_graphics.h
@@ -36,6 +36,7 @@ private:
     void SetupPerGameUI();
     void SetPhysicalDeviceComboVisibility(int index);
 
+    ConfigurationShared::CheckState use_gles;
     ConfigurationShared::CheckState use_hw_shader;
     ConfigurationShared::CheckState shaders_accurate_mul;
     ConfigurationShared::CheckState skip_slow_draw;

--- a/src/borked3ds_qt/configuration/configure_graphics.ui
+++ b/src/borked3ds_qt/configuration/configure_graphics.ui
@@ -62,10 +62,16 @@
             <property name="text">
              <string>OpenGL (default)</string>
             </property>
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use OpenGL renderer. Minimum requirement for GPU support is OpenGL 4.3.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
            </item>
            <item>
             <property name="text">
              <string>Vulkan</string>
+            </property>
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use Vulkan renderer. Minimum requirement for GPU support is Vulkan 1.2. Best results with Vulkan 1.3 or greater.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
            </item>
           </widget>
@@ -103,7 +109,7 @@
       </item>
       <item>
        <widget class="QWidget" name="opengl_renderer_group" native="true">
-        <layout class="QHBoxLayout" name="opengl_renderer_group_2">
+        <layout class="QGridLayout" name="opengl_renderer_group_2">
          <property name="leftMargin">
           <number>0</number>
          </property>
@@ -116,15 +122,25 @@
          <property name="bottomMargin">
           <number>0</number>
          </property>
-         <item>
+         <item row="0" column="0">
           <widget class="QLabel" name="opengl_renderer_label">
            <property name="text">
             <string>OpenGL Renderer</string>
            </property>
           </widget>
          </item>
-         <item>
+         <item row="0" column="1">
           <widget class="QLabel" name="opengl_renderer_name_label"/>
+         </item>
+         <item row="1" column="0">
+          <widget class="QCheckBox" name="toggle_use_gles">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use OpenGLES extensions instead of regular OpenGL. Primarily for use with GPUs on embedded systems. Minimum requirement for GPU support is OpenGLES 3.1. Best results with OpenGLES 3.2 or greater.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Use GLES extensions</string>
+           </property>
+          </widget>
          </item>
         </layout>
        </widget>

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -227,6 +227,7 @@ void RestoreGlobalState(bool is_powered_on) {
     // Renderer
     values.graphics_api.SetGlobal(true);
     values.physical_device.SetGlobal(true);
+    values.use_gles.SetGlobal(true);
     values.spirv_shader_gen.SetGlobal(true);
     values.geometry_shader.SetGlobal(true);
     values.use_sample_shading.SetGlobal(true);

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -504,7 +504,7 @@ struct Values {
 #endif
         GraphicsAPI::Software, GraphicsAPI::Vulkan, "graphics_api"};
     SwitchableSetting<u32> physical_device{0, "physical_device"};
-    Setting<bool> use_gles{false, "use_gles"};
+    SwitchableSetting<bool> use_gles{false, "use_gles"};
     Setting<bool> renderer_debug{false, "renderer_debug"};
     Setting<bool> dump_command_buffers{false, "dump_command_buffers"};
     SwitchableSetting<bool> spirv_shader_gen{true, "spirv_shader_gen"};


### PR DESCRIPTION
Useful for aarch64 based machines if OpenGL 4.3 isn't supported. Note that currently, only OpenGLES 3.2 is supported. OpenGLES 3.1 may work if certain additional extensions are supported through the GPU driver.